### PR TITLE
[Documentation] Fixes typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Definition Ecosystem vs. Ecosystem Framework:
 
-- A component ecosystem is a pool of components which can be used in any combination to build your websites or webaaplications user interface. The same components can be used in 1-n projects.
+- A component ecosystem is a pool of components which can be used in any combination to build your websites or web applications user interface. The same components can be used in 1-n projects.
 
 - An ecosystem framework helps you building such an ecosystem and makes sure all components play well with each other, you get an overview over all components in the pooland information how to use them.
 
@@ -29,7 +29,7 @@
 - Versioning enables you to use all ui-components independently in different projects.
 - Ensure a consistent UI across all your projects.
 - Let multiple partners contribute to the ui library without compatiblity & quality issues. Bring their design system to live. Real usable code, no dummy html components in a seperate styleguide tool.
--	Doesnt matter how big the component library gets. Projects only use components they need. So performance stays high.
+- Doesnt matter how big the component library gets. Projects only use components they need. So performance stays high.
 - Maintain and extend the ui library over years to avoid getting out-of-date and having to start from scratch again.
 
 


### PR DESCRIPTION
Fixed typo in `README.md` section "**Definition Ecosystem vs. Ecosystem Framework**", the first point "**webaaplications**" to "**web applications**"