### PR TITLE
fix: :bug: init function being called before script load

### DIFF
--- a/src/resources/ts/main.ts
+++ b/src/resources/ts/main.ts
@@ -1,15 +1,17 @@
 import ResourceLoader from '@biotope/resource-loader/lib/index.esm';
+const vm = require('vm');
 
 {
     const init = () => {
         const elementsWithDataInit: HTMLElement[] = [].slice.call(document.querySelectorAll('[data-init]'));
         elementsWithDataInit.forEach((element: HTMLElement) => {
-            const initFunction = eval(element.dataset.init);
+            const initFunction = vm.runInThisContext(element.dataset.init);
             initFunction(element);
         });
     }
 
-    const setupResourceLoader = () => {
+    const setupResourceLoader = (callback: Function) => {
+
         const cssHandler = {
             match: (options) => options.resource.path.indexOf('.css') > -1,
             handle: (options) => {
@@ -27,6 +29,7 @@ import ResourceLoader from '@biotope/resource-loader/lib/index.esm';
                 script.src = options.resource.path;
                 script.async = true;
                 document.body.appendChild(script);
+                script.onload = () => callback();
             }
         }
 
@@ -40,10 +43,8 @@ import ResourceLoader from '@biotope/resource-loader/lib/index.esm';
                 jsHandler
             ]
         });
+
     }
 
-    window.addEventListener('resourcesReady', () => {
-        init();
-    });
-    setupResourceLoader();
+    setupResourceLoader(init); 
 };


### PR DESCRIPTION
This PR is intended to solve issue #108 on **biotope-boilerplate** project and https://github.com/biotope/biotope-resource-loader/issues/10 on **biotope/resource loader**.

- Usage of VM to create a new node process, and escape eval declaration
- Add a callback function in order to compel the function initialisation only after loaded script